### PR TITLE
Add loading states to API calls in previews

### DIFF
--- a/src/views/Signatures/Studio/SignaturePreview/SignatureBuildPreview.jsx
+++ b/src/views/Signatures/Studio/SignaturePreview/SignatureBuildPreview.jsx
@@ -16,6 +16,7 @@ const SignatureBuildPreview = ({ id, styles }) => {
 
         const callPreviewAPI = async () => {
             try {
+                setError(null)
                 setLoading(true);
                 const response = await request.post(
                     "compile_for_create_signature/" + id,

--- a/src/views/Teams/SignaturePreview/Assign/EventManager/EventManager.jsx
+++ b/src/views/Teams/SignaturePreview/Assign/EventManager/EventManager.jsx
@@ -9,6 +9,7 @@ const EventManager = memo(({ editedEntity, setEditedEntityEvent }) => {
     const intl = useIntl();
 
     const [selectedEvent, setSelectedEvent] = useState(null);
+    const [loading, setLoading] = useState(false)
 
     const [selectedCampaigns, setSelectedCampaigns] = useState([]);
     const [showPlaylistEditor, setShowPlaylistEditor] = useState(false);
@@ -49,8 +50,9 @@ const EventManager = memo(({ editedEntity, setEditedEntityEvent }) => {
     const [playlistCampaignsList, setPlaylistCampaignsList] = useState([]);
 
     const fetchCampaigns = async () => {
+        setLoading(true)
         setCurrentCampaignsList([]);
-        request.get("events").then(({ data }) => {
+        await request.get("events").then(({ data }) => {
             let campaignsFetchedList = data["hydra:member"];
 
             setPlaylistCampaignsList(filterPastCampaigns(campaignsFetchedList));
@@ -60,6 +62,8 @@ const EventManager = memo(({ editedEntity, setEditedEntityEvent }) => {
             campaignsFetchedList.unshift(noCampaign);
             campaignsFetchedList.push(playlistOption);
             setCurrentCampaignsList(campaignsFetchedList);
+        }).finally(() => {
+            setLoading(false)
         });
     };
 
@@ -72,7 +76,7 @@ const EventManager = memo(({ editedEntity, setEditedEntityEvent }) => {
         const event = currentCampaignsList.find(
             (event) => event["@id"] === determineDefaultValue()
         );
-        setSelectedEvent(event);
+        setSelectedEvent(event); 
     }, [editedEntity]);
 
     const handleChangeCampaign = (eventId) => {
@@ -89,6 +93,9 @@ const EventManager = memo(({ editedEntity, setEditedEntityEvent }) => {
         setEditedEntityEvent(selectedCampaigns);
     };
 
+    if (loading)
+        return null;
+    
     return (
         <div>
             {currentCampaignsList.length > 0 && (

--- a/src/views/Teams/SignaturePreview/signaturePreview.jsx
+++ b/src/views/Teams/SignaturePreview/signaturePreview.jsx
@@ -6,7 +6,6 @@ import { request, useNotification } from "utils";
 import React, { useEffect, useState } from "react";
 import { SignatureManager } from "./Assign/SignatureManager/SignatureManager";
 import EventManager from "./Assign/EventManager/EventManager";
-import { AiOutlineEdit } from "react-icons/ai";
 
 export default function SignaturePreview({
                                              show, setShow, edit, setEdit, signatures
@@ -81,7 +80,7 @@ export default function SignaturePreview({
                             </span>
                     </h2>
                     <div className={classes.headerBtnsContainer}>
-                        <AiOutlineEdit fontSize="1.5rem" onClick={() => setEdit(show)} />
+                        {displayedSignature && (<CopyButton signature={displayedSignature} />)}
                         {type === "workplace" ? (<Button
                             color="secondary"
                             onClick={() => {
@@ -99,7 +98,6 @@ export default function SignaturePreview({
                     {fetchingSignature ? (
                         <Loading />) : (parse(displayedSignature || intl.formatMessage({ id: "statistic.no_signature" })))}
                 </div>
-                {displayedSignature && (<CopyButton signature={displayedSignature} />)}
 
             </div>
             <div className={classes.back}>


### PR DESCRIPTION
In all API calls within the Signature and Event Manager views, loading states have been added to provide better handling of states during the async calls. Prior to API call execution, the 'loading' state is set to true and upon completion, it is reset to false. Only when the 'loading' state is false, the relevant components are rendered.