### PR TITLE
Revise logo location referencing in ThemeProvider

### DIFF
--- a/src/contexts/ThemeProvider.jsx
+++ b/src/contexts/ThemeProvider.jsx
@@ -17,7 +17,7 @@ const ThemeProvider = ({ children }) => {
                 const fetchInstance = await getInstance(url);
                 setTheme(fetchedTheme.styles);
                 setName(fetchInstance.name);
-                setLogo(fetchInstance.organisation?.logoDistributor);
+                setLogo(fetchInstance.organisation?.logoDistributor.url);
             } catch (error) {
                 console.error(
                     "Erreur lors de la récupération des couleurs :",


### PR DESCRIPTION
The code fetches instance's organisation logo distributor information which can now point to the correct url. This ensures that the client correctly displays the distributor's logo and avoid cases where the image does not load due to incorrect url.